### PR TITLE
fix: add fallback for watchlist when quotes API fails

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -681,6 +681,20 @@ function App() {
             };
             return newData;
           }
+          // Fallback: Create item from WebSocket data if quotes API failed
+          const symbolData = watchlistSymbols.find(s =>
+            (typeof s === 'string' ? s : s.symbol) === ticker.symbol
+          );
+          if (symbolData) {
+            return [...prev, {
+              symbol: ticker.symbol,
+              exchange: typeof symbolData === 'string' ? 'NSE' : (symbolData.exchange || 'NSE'),
+              last: ticker.last.toFixed(2),
+              chg: ticker.chg.toFixed(2),
+              chgP: ticker.chgP.toFixed(2) + '%',
+              up: ticker.chg >= 0
+            }];
+          }
           return prev;
         });
       });


### PR DESCRIPTION
## Summary
- Adds fallback logic to create watchlist items from WebSocket data when the quotes API doesn't return data for a symbol
- Ensures watchlist displays real-time data even if initial API fetch fails

## Test plan
- [ ] Add a symbol to watchlist
- [ ] Verify it displays even if quotes API is slow/fails
- [ ] Confirm real-time updates work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)