### PR TITLE
feat: Add Sequential Drawing Mode toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -763,6 +763,7 @@ function AppContent({ isAuthenticated, setIsAuthenticated }) {
   const [isReplayMode, setIsReplayMode] = useState(false);
   const [isDrawingsLocked, setIsDrawingsLocked] = useState(false);
   const [isDrawingsHidden, setIsDrawingsHidden] = useState(false);
+  const [isSequentialMode, setIsSequentialMode] = useState(false); // Sequential drawing mode - keeps tool active after use
   const [isTimerVisible, setIsTimerVisible] = useLocalStorage('oa_timer_visible', false);
   const [isSessionBreakVisible, setIsSessionBreakVisible] = useLocalStorage('oa_session_break_visible', false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -822,7 +823,9 @@ function AppContent({ isAuthenticated, setIsAuthenticated }) {
     currentSymbol,
     showToast,
     showSnapshotToast,
-    requestConfirm
+    requestConfirm,
+    isSequentialMode,
+    setIsSequentialMode
   });
 
   // UI handlers extracted to hook
@@ -2029,6 +2032,7 @@ function AppContent({ isAuthenticated, setIsAuthenticated }) {
             isDrawingsLocked={isDrawingsLocked}
             isDrawingsHidden={isDrawingsHidden}
             isTimerVisible={isTimerVisible}
+            isSequentialMode={isSequentialMode}
           />
         }
         drawingPropertiesPanel={

--- a/src/components/Toolbar/DrawingToolbar.jsx
+++ b/src/components/Toolbar/DrawingToolbar.jsx
@@ -4,7 +4,7 @@ import styles from './DrawingToolbar.module.css';
 import * as Icons from './ToolIcons';
 import FloatingFavoritesToolbar from './FloatingFavoritesToolbar';
 
-const DrawingToolbar = ({ activeTool, onToolChange, isDrawingsLocked = false, isDrawingsHidden = false, isTimerVisible = false }) => {
+const DrawingToolbar = ({ activeTool, onToolChange, isDrawingsLocked = false, isDrawingsHidden = false, isTimerVisible = false, isSequentialMode = false }) => {
     // Group definitions
     const toolGroups = [
         {
@@ -96,6 +96,12 @@ const DrawingToolbar = ({ activeTool, onToolChange, isDrawingsLocked = false, is
             id: 'lock_group',
             items: [
                 { id: 'lock_all', icon: Icons.LockDrawingsIcon, label: 'Lock All Drawing Tools' }
+            ]
+        },
+        {
+            id: 'sequential_group',
+            items: [
+                { id: 'sequential_mode', icon: Icons.SequentialDrawingIcon, label: 'Sequential Drawing Mode' }
             ]
         },
         {
@@ -235,7 +241,8 @@ const DrawingToolbar = ({ activeTool, onToolChange, isDrawingsLocked = false, is
                 const isToggleActive =
                     (activeItem.id === 'lock_all' && isDrawingsLocked) ||
                     (activeItem.id === 'hide_drawings' && isDrawingsHidden) ||
-                    (activeItem.id === 'show_timer' && isTimerVisible);
+                    (activeItem.id === 'show_timer' && isTimerVisible) ||
+                    (activeItem.id === 'sequential_mode' && isSequentialMode);
                 const isActive = isToggleActive || activeTool === activeItem.id || group.items.some(i => i.id === activeTool);
                 const showArrow = group.items.length > 1;
 
@@ -350,7 +357,8 @@ DrawingToolbar.propTypes = {
     onToolChange: PropTypes.func.isRequired,
     isDrawingsLocked: PropTypes.bool,
     isDrawingsHidden: PropTypes.bool,
-    isTimerVisible: PropTypes.bool
+    isTimerVisible: PropTypes.bool,
+    isSequentialMode: PropTypes.bool
 };
 
 export default DrawingToolbar;

--- a/src/components/Toolbar/ToolIcons.jsx
+++ b/src/components/Toolbar/ToolIcons.jsx
@@ -389,3 +389,15 @@ export const ArcIcon = ({ size = 28, ...props }) => (
     </svg>
 );
 ArcIcon.propTypes = IconPropTypes;
+
+// Sequential Drawing Mode Icon - keeps tool active after drawing
+export const SequentialDrawingIcon = ({ size = 28, ...props }) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28" width={size} height={size} fill="currentColor" {...props}>
+        <path d="M4 6h2v2H4zM4 12h2v2H4zM4 18h2v2H4zM10 6h2v2h-2zM10 12h2v2h-2zM10 18h2v2h-2zM16 6h2v2h-2zM16 12h2v2h-2zM16 18h2v2h-2zM22 6h2v2h-2zM22 12h2v2h-2zM22 18h2v2h-2z"></path>
+        <path d="M7 7h2v12H7z" opacity="0.5"></path>
+        <path d="M13 7h2v12h-2z" opacity="0.5"></path>
+        <path d="M19 7h2v12h-2z" opacity="0.5"></path>
+    </svg>
+);
+SequentialDrawingIcon.propTypes = IconPropTypes;
+

--- a/src/hooks/useToolHandlers.js
+++ b/src/hooks/useToolHandlers.js
@@ -21,6 +21,8 @@ import html2canvas from 'html2canvas';
  * @param {string} params.currentSymbol - Current chart symbol
  * @param {Function} params.showToast - Toast notification function
  * @param {Function} params.showSnapshotToast - Snapshot toast function
+ * @param {boolean} params.isSequentialMode - If true, keep tool active after drawing
+ * @param {Function} params.setIsSequentialMode - State setter for sequential mode
  * @returns {Object} Tool handler functions
  */
 export const useToolHandlers = ({
@@ -36,7 +38,9 @@ export const useToolHandlers = ({
     currentSymbol,
     showToast,
     showSnapshotToast,
-    requestConfirm
+    requestConfirm,
+    isSequentialMode = false,
+    setIsSequentialMode
 }) => {
     // Toggle drawing toolbar visibility
     const toggleDrawingToolbar = useCallback(() => {
@@ -47,6 +51,11 @@ export const useToolHandlers = ({
     const handleToolChange = useCallback((tool) => {
         if (tool === 'magnet') {
             setIsMagnetMode(prev => !prev);
+        } else if (tool === 'sequential_mode') {
+            // Toggle sequential drawing mode
+            if (setIsSequentialMode) {
+                setIsSequentialMode(prev => !prev);
+            }
         } else if (tool === 'undo') {
             const activeRef = chartRefs.current[activeChartId];
             if (activeRef) {
@@ -104,10 +113,13 @@ export const useToolHandlers = ({
         }
     }, [chartRefs, activeChartId, setActiveTool, setIsMagnetMode, setIsDrawingsHidden, setIsDrawingsLocked, setIsTimerVisible]);
 
-    // Reset active tool after use
+    // Reset active tool after use (unless sequential mode is enabled)
     const handleToolUsed = useCallback(() => {
-        setActiveTool(null);
-    }, [setActiveTool]);
+        if (!isSequentialMode) {
+            setActiveTool(null);
+        }
+        // In sequential mode, keep the tool active so user can draw again
+    }, [setActiveTool, isSequentialMode]);
 
     // Undo wrapper
     const handleUndo = useCallback(() => {


### PR DESCRIPTION
## Summary
Adds a toggle button for "Sequential Drawing Mode" that keeps drawing tools active after completing a drawing, allowing users to draw multiple instances without re-selecting the tool.

## Problem
Currently, after drawing a trendline (or any drawing tool), the tool automatically deselects. Users must right-click and re-select the tool each time they want to draw another line.

## Solution
When Sequential Drawing Mode is enabled:
- The handleToolUsed() callback no longer resets activeTool to null
- - Drawing tools stay selected after each use
- - Users can draw as many lines as needed, then click ESC or another tool to exit
## Changes
| File | Change |
|------|--------|
| src/hooks/useToolHandlers.js | Added isSequentialMode parameter; skip tool reset when enabled |
| src/App.jsx | Added isSequentialMode state and wiring |
| src/components/Toolbar/DrawingToolbar.jsx | Added sequential mode toggle button |
| src/components/Toolbar/ToolIcons.jsx | Added SequentialDrawingIcon |
